### PR TITLE
Fix padding bug in crop_or_pad_img

### DIFF
--- a/livecellx/core/utils.py
+++ b/livecellx/core/utils.py
@@ -162,16 +162,30 @@ def crop_or_pad_img(img_crop, fix_dims):
     if fix_dims is not None:
         if img_crop.shape[0] > fix_dims[0]:
             start = (img_crop.shape[0] - fix_dims[0]) // 2
-            img_crop = img_crop[start : start + fix_dims[0], :]
+            end = start + fix_dims[0]
+            img_crop = img_crop[start:end, :]
         else:
-            pad = (fix_dims[0] - img_crop.shape[0]) // 2
-            img_crop = np.pad(img_crop, ((pad, pad), (0, 0)), mode="constant", constant_values=0)
+            pad_before = (fix_dims[0] - img_crop.shape[0]) // 2
+            pad_after = fix_dims[0] - img_crop.shape[0] - pad_before
+            img_crop = np.pad(
+                img_crop,
+                ((pad_before, pad_after), (0, 0)),
+                mode="constant",
+                constant_values=0,
+            )
 
         if img_crop.shape[1] > fix_dims[1]:
             start = (img_crop.shape[1] - fix_dims[1]) // 2
-            img_crop = img_crop[:, start : start + fix_dims[1]]
+            end = start + fix_dims[1]
+            img_crop = img_crop[:, start:end]
         else:
-            pad = (fix_dims[1] - img_crop.shape[1]) // 2
-            img_crop = np.pad(img_crop, ((0, 0), (pad, pad)), mode="constant", constant_values=0)
+            pad_before = (fix_dims[1] - img_crop.shape[1]) // 2
+            pad_after = fix_dims[1] - img_crop.shape[1] - pad_before
+            img_crop = np.pad(
+                img_crop,
+                ((0, 0), (pad_before, pad_after)),
+                mode="constant",
+                constant_values=0,
+            )
 
     return img_crop

--- a/tests/test_crop_or_pad_img.py
+++ b/tests/test_crop_or_pad_img.py
@@ -1,0 +1,44 @@
+import importlib.util
+import types
+import sys
+from pathlib import Path
+import numpy as np
+
+# Provide a minimal stub for livecellx.preprocess.utils with normalize_img_to_uint8
+prep_module = types.ModuleType("livecellx.preprocess.utils")
+
+def normalize_img_to_uint8(img: np.ndarray, dtype=np.uint8) -> np.ndarray:
+    std = np.std(img.flatten())
+    if std != 0:
+        img = (img - np.mean(img.flatten())) / std
+    else:
+        img = img - np.mean(img.flatten())
+    img = img + abs(np.min(img.flatten()))
+    if np.max(img) != 0:
+        img = img / np.max(img) * 255
+    return img.astype(dtype)
+
+prep_module.normalize_img_to_uint8 = normalize_img_to_uint8
+sys.modules.setdefault("livecellx", types.ModuleType("livecellx"))
+sys.modules.setdefault("livecellx.preprocess", types.ModuleType("livecellx.preprocess"))
+sys.modules["livecellx.preprocess.utils"] = prep_module
+
+# Load the core utils module directly
+utils_path = Path(__file__).resolve().parents[1] / "livecellx" / "core" / "utils.py"
+utils_spec = importlib.util.spec_from_file_location("core_utils", utils_path)
+core_utils = importlib.util.module_from_spec(utils_spec)
+utils_spec.loader.exec_module(core_utils)
+
+crop_or_pad_img = core_utils.crop_or_pad_img
+
+
+def test_pad_odd_difference():
+    img = np.zeros((64, 64), dtype=np.uint8)
+    result = crop_or_pad_img(img.copy(), (65, 65))
+    assert result.shape == (65, 65)
+
+
+def test_crop_odd_difference():
+    img = np.zeros((64, 64), dtype=np.uint8)
+    result = crop_or_pad_img(img.copy(), (63, 63))
+    assert result.shape == (63, 63)


### PR DESCRIPTION
## Summary
- fix incorrect padding when target size has odd dimensions
- add regression tests for `crop_or_pad_img`

## Testing
- `pytest tests/test_crop_or_pad_img.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc7fd98288331aa8d91e0ffa944de